### PR TITLE
Update WoS access to use the AU operator (ALL is not permitted). 

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1037,7 +1037,13 @@ async def get_web_of_science_results(query: str, fields: List[str], num_results:
         return []
     
     # Format query with proper WoS syntax
-    wos_query = f'AU=({query})'
+    #Allowed tags are AI, AU, CS, DO, DT, FPY, IS, OG, PG, PMID, PY, SO, SUR, TI, TS, UT, VL.
+    # use AU for author, FPY for final publication year, OG for organization-enhanced, PY for year published
+    # use PMID for PubMed ID, SO for publication name,
+    # TS for topic terms in Title, Abstract, Author Keywords, Keywords Plus fields.
+    # UT for accession number (a UUID)
+    # Likely best query is AU=(q) OR TS=(q)
+    wos_query = f'AU=({query}) OR TS=({query})'
     
     headers = {
         "X-ApiKey": WOS_API_KEY,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1533,7 +1533,6 @@ async def compare_search_results(request: SearchRequest):
         source_task_map[task] = "semanticScholar"
     
     if "webOfScience" in request.sources:
-        logger.info(f'WoS {request.query}')
         task = asyncio.create_task(get_web_of_science_results(request.query, request.fields))
         tasks.append(task)
         source_task_map[task] = "webOfScience"


### PR DESCRIPTION
This searches the author field (AU). The query generation should probably be updated to do an OR over the fields of interest. 

Allowed tags are AI, AU, CS, DO, DT, FPY, IS, OG, PG, PMID, PY, SO, SUR, TI, TS, UT, VL. 

Field tag documentation: https://webofscience.help.clarivate.com/en-us/Content/wos-core-collection/woscc-search-field-tags.htm

Update the response extraction to get the hits element, and then properly extract the necessary fields.